### PR TITLE
fix install

### DIFF
--- a/kizmi/extended_python/helper.py
+++ b/kizmi/extended_python/helper.py
@@ -1,5 +1,4 @@
 from rbnf.core.Tokenizer import Tokenizer
-from toolz import compose
 import ast
 import typing as t
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from setuptools import setup
-from Redy.Tools.Version import Version
-from Redy.Tools.PathLib import Path
+
 #
 # with open('./README.md', encoding='utf-8') as f:
 #     readme = f.read()
@@ -26,7 +25,7 @@ setup(
         ]
     },
     install_requires=[
-        'Redy', 'rbnf>=0.3.21', 'wisepy', 'bytecode==0.7.0', 'toolz'
+        'Redy', 'rbnf>=0.3.21', 'wisepy', 'bytecode==0.7.0', 'yapf'
     ],
     platforms='any',
     classifiers=[


### PR DESCRIPTION
`setup.py` failed with `ModuleNotFoundError: No module named 'Redy'`.

`yapf` is required by dbg, but not listed in `install_requires`.